### PR TITLE
fix: menu dropdown behind hero image

### DIFF
--- a/src/components/navbar/dropdown.astro
+++ b/src/components/navbar/dropdown.astro
@@ -24,7 +24,7 @@ const { title, lastItem, children } = Astro.props;
     <DropdownItems>
       <div
         class:list={[
-          "lg:absolute  w-full  lg:w-48",
+          "lg:absolute w-full lg:w-48 z-10",
           lastItem
             ? "lg:right-0 origin-top-right"
             : "lg:left-0 origin-top-left",


### PR DESCRIPTION
Hi!
This commit fixes an issue with the hero image and the dropdown.
Before the fix:
![image](https://user-images.githubusercontent.com/15352074/222978502-f131069c-9672-4846-a4f7-31a279402339.png)
After the fix:
![image](https://user-images.githubusercontent.com/15352074/222978528-c612cb13-84c4-4b8f-9877-2825b57df9a4.png)
