### PR TITLE
Remove footer component import

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,6 @@
 import Container from "@components/container.astro";
 import Cta from "@components/cta.astro";
 import Features from "@components/features.astro";
-import Footer from "@components/footer.astro";
 import Hero from "@components/hero.astro";
 import Logos from "@components/logos.astro";
 import Layout from "@layouts/Layout.astro";


### PR DESCRIPTION
The footer component is now in the layout, this import is no longer needed in index.astro