### PR TITLE
docs: add deploy to Zeabur in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Click here to deploy on Netlify:
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/surjithctly/astroship)
 
+Click here to deploy on Zeabur:
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/RDAHGW)
+
 ## Preview
 
 ![image](https://user-images.githubusercontent.com/1884712/200831799-10ef2456-a02e-4068-b580-4b5326f0b33b.png)


### PR DESCRIPTION
Deploy Astroship with one click on Zeabur. Preview link: https://astroship.zeabur.app

<img width="1512" alt="Snipaste_2024-01-16_11-35-57" src="https://github.com/surjithctly/astroship/assets/63531512/9d47cd90-e2dd-4d20-a1cd-90d9117e5f17">
